### PR TITLE
Feat/16-ranking-batch

### DIFF
--- a/src/main/java/com/finlearn/rankingservice/RankingServiceApplication.java
+++ b/src/main/java/com/finlearn/rankingservice/RankingServiceApplication.java
@@ -2,8 +2,10 @@ package com.finlearn.rankingservice;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.scheduling.annotation.EnableScheduling;
 
 @SpringBootApplication
+@EnableScheduling
 public class RankingServiceApplication {
 
     public static void main(String[] args) {

--- a/src/main/java/com/finlearn/rankingservice/application/RankingService.java
+++ b/src/main/java/com/finlearn/rankingservice/application/RankingService.java
@@ -3,6 +3,9 @@ package com.finlearn.rankingservice.application;
 import com.finlearn.common.exception.ConflictException;
 import com.finlearn.rankingservice.application.command.AchievementUnlockedCommand;
 import com.finlearn.rankingservice.application.command.InvestmentChangedCommand;
+import com.finlearn.rankingservice.application.command.PortfolioSnapshotCommand;
+import com.finlearn.rankingservice.domain.PortfolioSnapshot;
+import com.finlearn.rankingservice.domain.repository.PortfolioSnapshotRepository;
 import com.finlearn.rankingservice.application.dto.*;
 import com.finlearn.rankingservice.domain.Ranking;
 import com.finlearn.rankingservice.domain.RankingBadge;
@@ -33,6 +36,7 @@ public class RankingService {
     private final RankingBadgeRepository rankingBadgeRepository;
     private final RankingScoreRepository rankingScoreRepository;
     private final RankingEventPublisher rankingEventPublisher;
+    private final PortfolioSnapshotRepository portfolioSnapshotRepository;
 
     /**
      * 시즌 랭킹 조회
@@ -71,6 +75,16 @@ public class RankingService {
             return rankingBadgeRepository.findAllByUserIdAndSeasonId(userId, seasonId);
         }
         return rankingBadgeRepository.findAllByUserIdOrderByPaidAtDesc(userId);
+    }
+
+    /**
+     * 특정 시즌 유저의 ALL 랭킹 확정 순위 조회: season-service 시드머니 산정용
+     * 랭킹 확정 이후에만 rank 존재, 이전에는 null 반환
+     */
+    public Integer getUserAllRank(UUID seasonId, UUID userId) {
+        return rankingRepository.findBySeasonIdAndUserIdAndRankingType(seasonId, userId, RankingType.ALL)
+                .map(Ranking::getRank)
+                .orElse(null);
     }
 
     /** 랭킹 점수 직접 갱신 (simulation-service 내부 호출) */
@@ -172,6 +186,76 @@ public class RankingService {
             createSnapshotIfAbsent(seasonId, command.getSeasonNumber(), userId,
                     command.getUserNickname(), command.getUserProfileImage(), RankingType.ETF);
         }
+    }
+
+    /**
+     * simulation.portfolio.snapshot 수신
+     * - portfolio_snapshots 테이블에 유저별 최신 수익률 upsert
+     * - Redis 갱신은 1시간 스케줄러가 담당
+     */
+    @Transactional
+    public void handlePortfolioSnapshot(PortfolioSnapshotCommand command) {
+        UUID userId = command.getUserId();
+        UUID seasonId = command.getSeasonId();
+
+        portfolioSnapshotRepository.findByUserIdAndSeasonId(userId, seasonId)
+                .ifPresentOrElse(
+                        snapshot -> snapshot.updateRates(
+                                command.getOverallReturnRate(),
+                                command.getStockReturnRate(),
+                                command.getEtfReturnRate()),
+                        () -> portfolioSnapshotRepository.save(PortfolioSnapshot.builder()
+                                .userId(userId)
+                                .seasonId(seasonId)
+                                .seasonNumber(command.getSeasonNumber() != null ? command.getSeasonNumber() : 0)
+                                .overallReturnRate(command.getOverallReturnRate())
+                                .stockReturnRate(command.getStockReturnRate())
+                                .etfReturnRate(command.getEtfReturnRate())
+                                .userNickname(command.getUserNickname())
+                                .userProfileImage(command.getUserProfileImage())
+                                .build())
+                );
+
+        // JPA 스냅샷 초기화
+        createSnapshotIfAbsent(seasonId, command.getSeasonNumber(), userId,
+                command.getUserNickname(), command.getUserProfileImage(), RankingType.ALL);
+        createSnapshotIfAbsent(seasonId, command.getSeasonNumber(), userId,
+                command.getUserNickname(), command.getUserProfileImage(), RankingType.STOCK);
+        createSnapshotIfAbsent(seasonId, command.getSeasonNumber(), userId,
+                command.getUserNickname(), command.getUserProfileImage(), RankingType.ETF);
+
+        log.debug("[RankingService] 포트폴리오 스냅샷 저장: userId={}, overall={}",
+                userId, command.getOverallReturnRate());
+    }
+
+    /**
+     * 1시간 주기 Redis 점수 갱신
+     * portfolio_snapshots 테이블의 최신값으로 Redis Sorted Set을 일괄 갱신
+     */
+    @Transactional(readOnly = true)
+    public void refreshRankingScores(UUID seasonId) {
+        if (rankingRepository.existsBySeasonIdAndRankNotNull(seasonId)) {
+            log.debug("[RankingService] 이미 확정된 시즌 갱신 건너뜀: seasonId={}", seasonId);
+            return;
+        }
+        List<PortfolioSnapshot> snapshots = portfolioSnapshotRepository.findAllBySeasonId(seasonId);
+        for (PortfolioSnapshot snap : snapshots) {
+            UUID userId = snap.getUserId();
+            rankingScoreRepository.updateScore(seasonId, RankingType.ALL,   userId, snap.getOverallReturnRate());
+            rankingScoreRepository.updateScore(seasonId, RankingType.STOCK, userId, snap.getStockReturnRate());
+            rankingScoreRepository.updateScore(seasonId, RankingType.ETF,   userId, snap.getEtfReturnRate());
+        }
+        log.info("[RankingService] Redis 점수 갱신 완료: seasonId={}, count={}", seasonId, snapshots.size());
+    }
+
+    /**
+     * 스냅샷이 존재하는 모든 미확정 시즌의 Redis 점수 갱신
+     * 스케줄러 진입점
+     */
+    @Transactional(readOnly = true)
+    public void refreshAllActiveSeasonScores() {
+        List<UUID> seasonIds = portfolioSnapshotRepository.findDistinctSeasonIds();
+        seasonIds.forEach(this::refreshRankingScores);
     }
 
     /**

--- a/src/main/java/com/finlearn/rankingservice/application/command/PortfolioSnapshotCommand.java
+++ b/src/main/java/com/finlearn/rankingservice/application/command/PortfolioSnapshotCommand.java
@@ -1,0 +1,19 @@
+package com.finlearn.rankingservice.application.command;
+
+import lombok.Builder;
+import lombok.Getter;
+import java.util.UUID;
+
+@Getter
+@Builder
+public class PortfolioSnapshotCommand {
+
+    private UUID userId;
+    private UUID seasonId;
+    private Integer seasonNumber;
+    private double overallReturnRate;
+    private double stockReturnRate;
+    private double etfReturnRate;
+    private String userNickname;
+    private String userProfileImage;
+}

--- a/src/main/java/com/finlearn/rankingservice/domain/PortfolioSnapshot.java
+++ b/src/main/java/com/finlearn/rankingservice/domain/PortfolioSnapshot.java
@@ -1,0 +1,82 @@
+package com.finlearn.rankingservice.domain;
+
+import com.finlearn.common.domain.BaseEntity;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+/**
+ * 유저별 최신 포트폴리오 스냅샷
+ * simulation.portfolio.snapshot 수신 시 upsert로 최신값 유지
+ * 1시간 스케줄러가 이 값으로 Redis Sorted Set을 갱신함
+ */
+@Getter
+@Entity
+@Table(
+        name = "portfolio_snapshots",
+        uniqueConstraints = @UniqueConstraint(
+                name = "uk_portfolio_snapshots_user_season",
+                columnNames = {"user_id", "season_id"}
+        )
+)
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class PortfolioSnapshot extends BaseEntity {
+
+    @Id
+    @Column(name = "snapshot_id")
+    private UUID snapshotId;
+
+    @Column(name = "user_id", nullable = false)
+    private UUID userId;
+
+    @Column(name = "season_id", nullable = false)
+    private UUID seasonId;
+
+    @Column(name = "season_number", nullable = false)
+    private Integer seasonNumber;
+
+    @Column(name = "overall_return_rate", nullable = false)
+    private double overallReturnRate;
+
+    @Column(name = "stock_return_rate", nullable = false)
+    private double stockReturnRate;
+
+    @Column(name = "etf_return_rate", nullable = false)
+    private double etfReturnRate;
+
+    @Column(name = "user_nickname")
+    private String userNickname;
+
+    @Column(name = "user_profile_image")
+    private String userProfileImage;
+
+    @Column(name = "snapshotted_at", nullable = false)
+    private LocalDateTime snapshottedAt;
+
+    @Builder
+    private PortfolioSnapshot(UUID userId, UUID seasonId, Integer seasonNumber,
+                               double overallReturnRate, double stockReturnRate, double etfReturnRate,
+                               String userNickname, String userProfileImage) {
+        this.snapshotId = UUID.randomUUID();
+        this.userId = userId;
+        this.seasonId = seasonId;
+        this.seasonNumber = seasonNumber;
+        this.overallReturnRate = overallReturnRate;
+        this.stockReturnRate = stockReturnRate;
+        this.etfReturnRate = etfReturnRate;
+        this.userNickname = userNickname;
+        this.userProfileImage = userProfileImage;
+        this.snapshottedAt = LocalDateTime.now();
+    }
+
+    public void updateRates(double overallReturnRate, double stockReturnRate, double etfReturnRate) {
+        this.overallReturnRate = overallReturnRate;
+        this.stockReturnRate = stockReturnRate;
+        this.etfReturnRate = etfReturnRate;
+        this.snapshottedAt = LocalDateTime.now();
+    }
+}

--- a/src/main/java/com/finlearn/rankingservice/domain/repository/PortfolioSnapshotRepository.java
+++ b/src/main/java/com/finlearn/rankingservice/domain/repository/PortfolioSnapshotRepository.java
@@ -1,0 +1,17 @@
+package com.finlearn.rankingservice.domain.repository;
+
+import com.finlearn.rankingservice.domain.PortfolioSnapshot;
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+
+public interface PortfolioSnapshotRepository {
+
+    Optional<PortfolioSnapshot> findByUserIdAndSeasonId(UUID userId, UUID seasonId);
+
+    List<PortfolioSnapshot> findAllBySeasonId(UUID seasonId);
+
+    List<UUID> findDistinctSeasonIds();
+
+    PortfolioSnapshot save(PortfolioSnapshot snapshot);
+}

--- a/src/main/java/com/finlearn/rankingservice/infrastructure/kafka/RankingEventConsumer.java
+++ b/src/main/java/com/finlearn/rankingservice/infrastructure/kafka/RankingEventConsumer.java
@@ -5,6 +5,7 @@ import com.finlearn.common.exception.ConflictException;
 import com.finlearn.rankingservice.application.RankingService;
 import com.finlearn.rankingservice.application.command.AchievementUnlockedCommand;
 import com.finlearn.rankingservice.application.command.InvestmentChangedCommand;
+import com.finlearn.rankingservice.application.command.PortfolioSnapshotCommand;
 import com.finlearn.rankingservice.infrastructure.kafka.event.*;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -48,6 +49,36 @@ public class RankingEventConsumer {
 
         } catch (Exception e) {
             log.error("[Kafka] investment.changed 처리 실패: {}", e.getMessage(), e);
+            throw new RuntimeException(e.getMessage(), e);
+        }
+    }
+
+    /**
+     * simulation.portfolio.snapshot → 유저별 최신 수익률 DB upsert
+     */
+    @KafkaListener(
+            topics = "${kafka.topics.simulation.portfolio.snapshot}",
+            groupId = "${spring.kafka.consumer.group-id}"
+    )
+    public void handlePortfolioSnapshot(Object payload) {
+        try {
+            PortfolioSnapshotEvent event = objectMapper.convertValue(payload, PortfolioSnapshotEvent.class);
+
+            PortfolioSnapshotCommand command = PortfolioSnapshotCommand.builder()
+                    .userId(event.getUserId())
+                    .seasonId(event.getSeasonId())
+                    .seasonNumber(event.getSeasonNumber())
+                    .overallReturnRate(event.getOverallReturnRate())
+                    .stockReturnRate(event.getStockReturnRate())
+                    .etfReturnRate(event.getEtfReturnRate())
+                    .userNickname(event.getUserNickname())
+                    .userProfileImage(event.getUserProfileImage())
+                    .build();
+
+            rankingService.handlePortfolioSnapshot(command);
+
+        } catch (Exception e) {
+            log.error("[Kafka] simulation.portfolio.snapshot 처리 실패: {}", e.getMessage(), e);
             throw new RuntimeException(e.getMessage(), e);
         }
     }

--- a/src/main/java/com/finlearn/rankingservice/infrastructure/kafka/event/PortfolioSnapshotEvent.java
+++ b/src/main/java/com/finlearn/rankingservice/infrastructure/kafka/event/PortfolioSnapshotEvent.java
@@ -1,0 +1,28 @@
+package com.finlearn.rankingservice.infrastructure.kafka.event;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import java.util.UUID;
+
+/**
+ * simulation-service 발행 → ranking-service 수신
+ * 거래 체결 후 포트폴리오 갱신 시마다 발행 — 유저별 최신 수익률 저장 후 1시간 주기 순위 재산정
+ * topic: simulation.portfolio.snapshot
+ */
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class PortfolioSnapshotEvent {
+
+    private UUID userId;
+    private UUID seasonId;
+    private Integer seasonNumber;
+    private double overallReturnRate;
+    private double stockReturnRate;
+    private double etfReturnRate;
+    private int stockHoldingCount;
+    private int etfHoldingCount;
+    private String userNickname;
+    private String userProfileImage;
+}

--- a/src/main/java/com/finlearn/rankingservice/infrastructure/persistence/PortfolioSnapshotJpaRepository.java
+++ b/src/main/java/com/finlearn/rankingservice/infrastructure/persistence/PortfolioSnapshotJpaRepository.java
@@ -1,0 +1,19 @@
+package com.finlearn.rankingservice.infrastructure.persistence;
+
+import com.finlearn.rankingservice.domain.PortfolioSnapshot;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+
+public interface PortfolioSnapshotJpaRepository extends JpaRepository<PortfolioSnapshot, UUID> {
+
+    Optional<PortfolioSnapshot> findByUserIdAndSeasonId(UUID userId, UUID seasonId);
+
+    List<PortfolioSnapshot> findAllBySeasonId(UUID seasonId);
+
+    // 스냅샷이 존재하는 시즌 ID 목록 조회
+    @Query("SELECT DISTINCT p.seasonId FROM PortfolioSnapshot p")
+    List<UUID> findDistinctSeasonIds();
+}

--- a/src/main/java/com/finlearn/rankingservice/infrastructure/persistence/PortfolioSnapshotRepositoryImpl.java
+++ b/src/main/java/com/finlearn/rankingservice/infrastructure/persistence/PortfolioSnapshotRepositoryImpl.java
@@ -1,0 +1,36 @@
+package com.finlearn.rankingservice.infrastructure.persistence;
+
+import com.finlearn.rankingservice.domain.PortfolioSnapshot;
+import com.finlearn.rankingservice.domain.repository.PortfolioSnapshotRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+
+@Repository
+@RequiredArgsConstructor
+public class PortfolioSnapshotRepositoryImpl implements PortfolioSnapshotRepository {
+
+    private final PortfolioSnapshotJpaRepository jpaRepository;
+
+    @Override
+    public Optional<PortfolioSnapshot> findByUserIdAndSeasonId(UUID userId, UUID seasonId) {
+        return jpaRepository.findByUserIdAndSeasonId(userId, seasonId);
+    }
+
+    @Override
+    public List<PortfolioSnapshot> findAllBySeasonId(UUID seasonId) {
+        return jpaRepository.findAllBySeasonId(seasonId);
+    }
+
+    @Override
+    public List<UUID> findDistinctSeasonIds() {
+        return jpaRepository.findDistinctSeasonIds();
+    }
+
+    @Override
+    public PortfolioSnapshot save(PortfolioSnapshot snapshot) {
+        return jpaRepository.save(snapshot);
+    }
+}

--- a/src/main/java/com/finlearn/rankingservice/infrastructure/scheduler/RankingScheduler.java
+++ b/src/main/java/com/finlearn/rankingservice/infrastructure/scheduler/RankingScheduler.java
@@ -1,0 +1,30 @@
+package com.finlearn.rankingservice.infrastructure.scheduler;
+
+import com.finlearn.rankingservice.application.RankingService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+/**
+ * 1시간 주기 랭킹 점수 갱신 스케줄러
+ * portfolio_snapshots 테이블의 최신값을 읽어 Redis Sorted Set을 일괄 갱신한다.
+ * 실시간 Redis ZADD 대신 배치 방식으로 서버 부하를 줄인다.
+ */
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class RankingScheduler {
+
+    private final RankingService rankingService;
+
+    @Scheduled(cron = "0 0 * * * *")
+    public void refreshRankingScores() {
+        log.info("[Scheduler] 랭킹 점수 갱신 시작");
+        try {
+            rankingService.refreshAllActiveSeasonScores();
+        } catch (Exception e) {
+            log.error("[Scheduler] 랭킹 점수 갱신 중 오류: {}", e.getMessage(), e);
+        }
+    }
+}

--- a/src/main/java/com/finlearn/rankingservice/presentation/RankingInternalController.java
+++ b/src/main/java/com/finlearn/rankingservice/presentation/RankingInternalController.java
@@ -6,8 +6,10 @@ import com.finlearn.rankingservice.application.dto.RankingEntryDto;
 import com.finlearn.rankingservice.presentation.dto.request.UpdateRankingScoreRequest;
 import com.finlearn.rankingservice.presentation.dto.response.FinalizeRankingResponse;
 import com.finlearn.rankingservice.presentation.dto.response.RankingEntryResponse;
+import com.finlearn.rankingservice.presentation.dto.response.UserRankResponse;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 import java.util.UUID;
 
@@ -19,17 +21,31 @@ public class RankingInternalController {
     private final RankingService rankingService;
 
     /**
+     * GET /internal/v1/rankings/seasons/{seasonId}/rank?userId={userId}
+     * 시즌 종료 후 확정된 ALL 랭킹 순위 조회: 내부 API, season-service 시드머니 산정용
+     * 랭킹 확정 전에는 rank가 null로 반환됨
+     */
+    @GetMapping("/seasons/{seasonId}/rank")
+    public ResponseEntity<UserRankResponse> getUserRank(
+            @PathVariable UUID seasonId,
+            @RequestParam UUID userId
+    ) {
+        Integer rank = rankingService.getUserAllRank(seasonId, userId);
+        return ResponseEntity.ok(new UserRankResponse(userId, seasonId, rank));
+    }
+
+    /**
      * PATCH /internal/v1/rankings/seasons/{seasonId}/score
      * 랭킹 점수 갱신: 내부 API, simulation-service 호출
      */
     @PatchMapping("/seasons/{seasonId}/score")
-    public RankingEntryResponse updateScore(
+    public ResponseEntity<RankingEntryResponse> updateScore(
             @PathVariable UUID seasonId,
             @Valid @RequestBody UpdateRankingScoreRequest request
     ) {
         RankingEntryDto dto = rankingService.updateScore(
                 seasonId, request.getUserId(), request.getRankingType(), request.getScore().doubleValue());
-        return RankingEntryResponse.from(dto);
+        return ResponseEntity.ok(RankingEntryResponse.from(dto));
     }
 
     /**
@@ -38,16 +54,16 @@ public class RankingInternalController {
      * 이미 확정된 경우 409 반환
      */
     @PostMapping("/seasons/{seasonId}/finalize")
-    public FinalizeRankingResponse finalizeRankings(
+    public ResponseEntity<FinalizeRankingResponse> finalizeRankings(
             @PathVariable UUID seasonId,
             @RequestParam Integer seasonNumber
     ) {
         FinalizeDto dto = rankingService.finalizeRankings(seasonId, seasonNumber);
-        return FinalizeRankingResponse.builder()
+        return ResponseEntity.ok(FinalizeRankingResponse.builder()
                 .seasonId(dto.getSeasonId())
                 .finalizedAt(dto.getFinalizedAt())
                 .badgeIssuedCount(dto.getBadgeIssuedCount())
                 .status("FINALIZED")
-                .build();
+                .build());
     }
 }

--- a/src/main/java/com/finlearn/rankingservice/presentation/dto/response/UserRankResponse.java
+++ b/src/main/java/com/finlearn/rankingservice/presentation/dto/response/UserRankResponse.java
@@ -1,0 +1,14 @@
+package com.finlearn.rankingservice.presentation.dto.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import java.util.UUID;
+
+@Getter
+@AllArgsConstructor
+public class UserRankResponse {
+
+    private UUID userId;
+    private UUID seasonId;
+    private Integer rank;
+}

--- a/src/test/java/com/finlearn/rankingservice/application/RankingServiceTest.java
+++ b/src/test/java/com/finlearn/rankingservice/application/RankingServiceTest.java
@@ -7,6 +7,7 @@ import com.finlearn.rankingservice.application.dto.*;
 import com.finlearn.rankingservice.domain.Ranking;
 import com.finlearn.rankingservice.domain.RankingBadge;
 import com.finlearn.rankingservice.domain.event.RankingEventPublisher;
+import com.finlearn.rankingservice.domain.repository.PortfolioSnapshotRepository;
 import com.finlearn.rankingservice.domain.repository.RankingBadgeRepository;
 import com.finlearn.rankingservice.domain.repository.RankingRepository;
 import com.finlearn.rankingservice.domain.repository.RankingScoreRepository;
@@ -39,10 +40,11 @@ class RankingServiceTest {
 
     @InjectMocks RankingService rankingService;
 
-    @Mock RankingRepository      rankingRepository;
-    @Mock RankingBadgeRepository rankingBadgeRepository;
-    @Mock RankingScoreRepository rankingScoreRepository;
-    @Mock RankingEventPublisher  rankingEventPublisher;
+    @Mock RankingRepository          rankingRepository;
+    @Mock RankingBadgeRepository     rankingBadgeRepository;
+    @Mock RankingScoreRepository     rankingScoreRepository;
+    @Mock RankingEventPublisher      rankingEventPublisher;
+    @Mock PortfolioSnapshotRepository portfolioSnapshotRepository;
 
     private static final UUID SEASON_ID = UUID.randomUUID();
     private static final UUID USER_ID   = UUID.randomUUID();

--- a/src/test/java/com/finlearn/rankingservice/presentation/RankingInternalControllerTest.java
+++ b/src/test/java/com/finlearn/rankingservice/presentation/RankingInternalControllerTest.java
@@ -13,14 +13,20 @@ import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Import;
 import org.springframework.http.MediaType;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
+import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.MockMvc;
 import java.math.BigDecimal;
 import java.time.LocalDateTime;
 import java.util.Map;
 import java.util.UUID;
+import static org.mockito.ArgumentMatchers.anyDouble;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.BDDMockito.given;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch;
@@ -28,9 +34,21 @@ import static org.springframework.test.web.servlet.request.MockMvcRequestBuilder
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
 
 @WebMvcTest(RankingInternalController.class)
-@Import({GlobalExceptionAdviceImpl.class, CommonResponseAdvice.class})
+@Import({GlobalExceptionAdviceImpl.class, CommonResponseAdvice.class,
+         RankingInternalControllerTest.TestSecurityConfig.class})
 @DisplayName("RankingInternalController")
 class RankingInternalControllerTest {
+
+    @TestConfiguration
+    static class TestSecurityConfig {
+        @Bean
+        public SecurityFilterChain testSecurityFilterChain(HttpSecurity http) throws Exception {
+            return http
+                    .csrf(AbstractHttpConfigurer::disable)
+                    .authorizeHttpRequests(auth -> auth.anyRequest().permitAll())
+                    .build();
+        }
+    }
 
     @Autowired MockMvc      mockMvc;
     @Autowired ObjectMapper objectMapper;
@@ -56,7 +74,7 @@ class RankingInternalControllerTest {
                     .lastUpdatedAt(LocalDateTime.now())
                     .build();
 
-            given(rankingService.updateScore(eq(SEASON_ID), eq(USER_ID), eq(RankingType.ETF), eq(new BigDecimal("35.72"))))
+            given(rankingService.updateScore(eq(SEASON_ID), eq(USER_ID), eq(RankingType.ETF), anyDouble()))
                     .willReturn(dto);
 
             Map<String, Object> body = Map.of(

--- a/src/test/resources/logback-test.xml
+++ b/src/test/resources/logback-test.xml
@@ -1,0 +1,12 @@
+<configuration>
+    <appender name="CONSOLE" class="ch.qos.logback.core.ConsoleAppender">
+        <encoder>
+            <pattern>%d{HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg%n</pattern>
+        </encoder>
+    </appender>
+    <root level="WARN">
+        <appender-ref ref="CONSOLE"/>
+    </root>
+    <logger name="com.finlearn" level="INFO"/>
+    <logger name="org.springframework.test" level="INFO"/>
+</configuration>


### PR DESCRIPTION
## 🌱 설명
ranking-service 랭킹 갱신 구조 개선 및 season-service 연동 기능을 추가했습니다. 

- 실시간 Redis 갱신 → 1시간 배치 갱신 구조로 전환
- `portfolio.snapshot` 기반 DB upsert 후 Scheduler에서 Redis 일괄 반영
- 확정 시즌은 랭킹 갱신 제외
- `/internal/v1/rankings/seasons/{seasonId}/rank` 추가 
- season-service `RankingClient.getRank()` 실제 랭킹 반환 가능하도록 수정

## 📌 관련 이슈
> close #16

## 💻 커밋 유형
> 해당하는 항목에 `x`를 채워주세요.
- [x] feat : 새로운 기능 추가
- [x] refactor : 리팩토링
- [x] test : 테스트 코드, 리팩토링 테스트 코드 추가


## 📝 체크리스트
> PR 올리기 전에 아래 항목을 확인해주세요.
- [x] develop 브랜치 기준으로 feature 브랜치를 생성했나요?
- [x] 코드 컨벤션 및 스타일 가이드를 준수했나요?
- [x] 관련 이슈와 연결했나요?
- [x] 어려운 부분 / 공유가 필요한 부분에 주석을 추가했습니다.
- [x] 제가 작성한 코드를 스스로 리뷰했습니다.
- [x] 기존 테스트와 충돌하지 않음을 확인했나요?



    


    
